### PR TITLE
Add docs for GET /clean-numbers endpoint

### DIFF
--- a/api-reference/endpoint/Get-Clean-Numbers.mdx
+++ b/api-reference/endpoint/Get-Clean-Numbers.mdx
@@ -1,0 +1,4 @@
+---
+title: 'Get Clean Numbers'
+openapi: 'GET /clean-numbers'
+---

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -521,6 +521,57 @@
         }
       }
     },
+    "/clean-numbers": {
+      "get": {
+        "summary": "Get clean numbers",
+        "description": "Returns a list of active clean phone numbers that can be used as caller IDs for voicemail drops. Numbers are filtered by group (overseas or inhouse) and scoped to your organization.",
+        "parameters": [
+          {
+            "name": "group",
+            "in": "query",
+            "description": "The group of clean numbers to retrieve",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["overseas", "inhouse"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Clean numbers retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CleanNumbersResponse"
+                },
+                "example": {
+                  "numbers": [
+                    { "phone_number": "+18667734413" }
+                  ],
+                  "count": 1,
+                  "group": "overseas"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or missing group parameter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "error": "Invalid or missing group parameter",
+                  "message": "group must be one of: overseas, inhouse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/rpcCall": {
       "post": {
         "summary": "Make an RPC Call",
@@ -1531,6 +1582,34 @@
           }
         },
         "required": ["recording_url"]
+      },
+      "CleanNumbersResponse": {
+        "type": "object",
+        "properties": {
+          "numbers": {
+            "type": "array",
+            "description": "List of active clean phone numbers",
+            "items": {
+              "type": "object",
+              "properties": {
+                "phone_number": {
+                  "type": "string",
+                  "description": "Phone number in E.164 format"
+                }
+              }
+            }
+          },
+          "count": {
+            "type": "integer",
+            "description": "Total number of clean numbers returned"
+          },
+          "group": {
+            "type": "string",
+            "description": "The group that was queried",
+            "enum": ["overseas", "inhouse"]
+          }
+        },
+        "required": ["numbers", "count", "group"]
       },
       "Error": {
         "type": "object",

--- a/mint.json
+++ b/mint.json
@@ -71,6 +71,7 @@
       "group": "Communications",
       "pages": [
         "api-reference/endpoint/Drop-Voicemail",
+        "api-reference/endpoint/Get-Clean-Numbers",
         "api-reference/endpoint/RPC-Call",
         "api-reference/endpoint/Get-Call-Recordings",
         "api-reference/endpoint/Get-TCN-Call-Outcome"


### PR DESCRIPTION
## Summary
- Added `GET /clean-numbers` endpoint to OpenAPI spec with query param `group` (overseas/inhouse)
- Added `CleanNumbersResponse` schema
- Created `Get-Clean-Numbers.mdx` doc page
- Added to Communications section in nav (after Drop Voicemail)

Companion to collectwise-api#84

COL-21625