### PR TITLE
chore(docs): fix Request API Key mailto to mohammed@collectwise.com

### DIFF
--- a/authorization.mdx
+++ b/authorization.mdx
@@ -13,7 +13,7 @@ Reach out to our support team to get your API key and setup instructions. If you
 
 <CardGroup>
 
-<Card title="Request API Key" icon="key" href="mailto:vivek@collectwise.co">
+<Card title="Request API Key" icon="key" href="mailto:mohammed@collectwise.com">
   Contact our support team to request API access.
 </Card>
 <Card title="API Reference" icon="rocket" href="/api-reference/Debtor-Object">


### PR DESCRIPTION
The vivek@collectwise.co address was unreachable while the .co domain sits in registry redemption. Route the Card to the same support inbox the topbar Support link uses.