### PR TITLE
Add paymentLink field to debtor docs

### DIFF
--- a/api-reference/Debtor-Object.mdx
+++ b/api-reference/Debtor-Object.mdx
@@ -33,7 +33,7 @@ The Debtor object contains the following properties:
 - **amountPaid**: `number` – Total amount paid by the debtor so far
 - **callbackNumber**: `string` – Callback phone number
  - **creditorEmail**: `string` – Email address of the creditor
-- **paymentLink**: `string` – Link where the debtor can pay their balance, included in outreach messages
+- **paymentLink**: `string` – Link where the debtor can pay their balance, included in outreach
 
 ---
 

--- a/api-reference/Debtor-Object.mdx
+++ b/api-reference/Debtor-Object.mdx
@@ -33,6 +33,7 @@ The Debtor object contains the following properties:
 - **amountPaid**: `number` – Total amount paid by the debtor so far
 - **callbackNumber**: `string` – Callback phone number
  - **creditorEmail**: `string` – Email address of the creditor
+- **paymentLink**: `string` – Link where the debtor can pay their balance, included in outreach messages
 
 ---
 
@@ -59,6 +60,7 @@ The Debtor object contains the following properties:
   "interestDue": 250.00,
   "principalDue": 4750.00,
   "amountPaid": 1000.00,
-  "callbackNumber": "+18768828825"
+  "callbackNumber": "+18768828825",
+  "paymentLink": "https://abcbank.com/pay"
 }
 ```

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1265,6 +1265,10 @@
             "format": "float",
             "description": "Total amount paid by the debtor so far"
           },
+          "paymentLink": {
+            "type": "string",
+            "description": "Link where the debtor can pay their balance, included in outreach messages. Accepts a full URL or a domain (e.g., https://example.com/pay or www.example.com)."
+          },
           "customWorkflowID": {
             "type": "string",
             "description": "Custom workflow identifier for the debtor"
@@ -1486,6 +1490,11 @@
             "type": "number",
             "format": "float",
             "description": "Total amount paid by the debtor so far"
+          },
+          "paymentLink": {
+            "type": "string",
+            "nullable": true,
+            "description": "Payment link associated with the debtor, or null if none was provided."
           },
           "customWorkflowID": {
             "type": "string",

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1267,7 +1267,7 @@
           },
           "paymentLink": {
             "type": "string",
-            "description": "Link where the debtor can pay their balance, included in outreach messages. Accepts a full URL or a domain (e.g., https://example.com/pay or www.example.com)."
+            "description": "Link where the debtor can pay their balance, included in outreach. Accepts a full URL or a domain (e.g., https://example.com/pay or www.example.com)."
           },
           "customWorkflowID": {
             "type": "string",


### PR DESCRIPTION
## What

Documents the new optional `paymentLink` field on the debtor object, shipped in collectwise-api PR #93.

- **`NewDebtor`** (POST /debtor request): `paymentLink` — optional string, a debtor-facing payment link. Accepts a full URL or a bare domain (e.g. `https://example.com/pay` or `www.example.com`).
- **`DebtorResponse`** (returned by POST /debtor and GET /debtor/{debtorId}): `paymentLink` — string, nullable (null when none was provided).
- **Debtor Object reference** (`Debtor-Object.mdx`): added to Optional Properties and the example payload.

## Notes

- Scoped to where the field is actually supported. Bulk create (`POST /debtors`) and update do not accept `paymentLink`, so their schemas are unchanged.
- Descriptions follow the existing terse, consumer-facing style of the surrounding fields (no implementation/HTTP detail).
- Verified live against the dev deployment: accepted/rejected/empty cases and persistence all behave as documented.