### PR TITLE
Trim paymentLink response description

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1494,7 +1494,7 @@
           "paymentLink": {
             "type": "string",
             "nullable": true,
-            "description": "Payment link associated with the debtor, or null if none was provided."
+            "description": "Payment link associated with the debtor"
           },
           "customWorkflowID": {
             "type": "string",


### PR DESCRIPTION
Removes the redundant 'or null if none was provided' from the DebtorResponse `paymentLink` description. The `string | null` type (from `nullable: true`) already conveys this, and no other response field restates null in prose. Wording change only; the type is unchanged.