### PR TITLE
docs: add One-Time Text API endpoints

### DIFF
--- a/api-reference/Texting-Overview.mdx
+++ b/api-reference/Texting-Overview.mdx
@@ -6,8 +6,8 @@ description: 'Send a single, ad-hoc templated SMS to a phone number, preview how
 ## How it works
 
 The Texting endpoints let you send one-off SMS messages built from templates we
-configure for your account. Your organization is resolved from your
-`collectwise_key` API key, so there is no client id in the path.
+configure for your account. Your account is identified by your `collectwise_key`
+API key, sent in the header on every request.
 
 <Note>
   Texting must be enabled for your organization before these endpoints will

--- a/api-reference/Texting-Overview.mdx
+++ b/api-reference/Texting-Overview.mdx
@@ -1,0 +1,86 @@
+---
+title: 'Texting Overview'
+description: 'Send a single, ad-hoc templated SMS to a phone number, preview how many segments it will use, and check delivery status.'
+---
+
+## How it works
+
+The Texting endpoints let you send one-off SMS messages built from templates we
+configure for your account. Your organization is resolved from your
+`collectwise_key` API key, so there is no client id in the path.
+
+<Note>
+  Texting must be enabled for your organization before these endpoints will
+  respond. If you receive a `403` on every call, contact us to have your
+  organization enabled.
+</Note>
+
+A typical integration is:
+
+<Steps>
+  <Step title="Discover templates">
+    Call [List SMS Templates](/api-reference/endpoint/Text-List-Templates) to
+    see the templates available to your account and the placeholder variables
+    each one expects.
+  </Step>
+  <Step title="(Optional) Preview segments">
+    Call [Calculate SMS Segments](/api-reference/endpoint/Text-Segments) to see
+    how many SMS segments a message or rendered template will use, before
+    sending.
+  </Step>
+  <Step title="Send">
+    Call [Send a Text](/api-reference/endpoint/Text-Send) with the `templateId`
+    and a `variables` object filling in every placeholder. A `200` means the
+    message was accepted and queued, and returns a `messageId`.
+  </Step>
+  <Step title="Check status">
+    Poll [Get Text Status](/api-reference/endpoint/Text-Status) with the
+    `messageId`. Delivery reports arrive asynchronously, so check after a short
+    delay.
+  </Step>
+</Steps>
+
+## Templates and variables
+
+Each template has a `templateId` and a `message` body containing `{placeholder}`
+tokens. The `placeholders` array on a template lists exactly which keys you must
+supply in `variables` when sending. If any placeholder is left unresolved, the
+send fails with `400` rather than texting a literal `{placeholder}` to the
+recipient.
+
+Placeholders use single curly braces and are matched exactly first, then
+normalized (case-insensitive, ignoring `#` and spaces), so `{FirstName}`,
+`{#FileNumber}`, and `{Variable Name}` all work.
+
+## Segments and encoding
+
+SMS messages are billed and split into segments by character count and
+encoding, matching the
+[Twilio segment calculator](https://twiliodeved.github.io/message-segment-calculator/):
+
+- **GSM-7**: 160 characters in a single segment, 153 per segment when the
+  message spans multiple segments.
+- **UCS-2**: 70 characters single, 67 per segment when multi-part. Any character
+  outside the GSM-7 set (emoji, smart quotes, most CJK) forces the entire
+  message to UCS-2.
+- The extended GSM-7 characters `{ } [ ] ~ \ | ^ €` cost two units each.
+
+## Delivery status
+
+A message moves through `Queued` → `Sent` → `Delivered`, or ends in `Rejected` /
+`Failed` / `Undelivered`. For failed messages, `failureClassification` indicates
+whether a retry is worthwhile:
+
+| Classification | Meaning |
+|---|---|
+| `FATAL` | Will never deliver as-is (e.g. invalid number, blocked, flagged as spam). Do not retry. |
+| `NON_FATAL` | Transient (e.g. absent subscriber, temporary carrier failure). `retryRecommended` is `true`. |
+| `null` | The carrier reason was not recognized. |
+
+## Rate limits
+
+- **Send**: 10 requests per minute per organization.
+- **Reads** (templates, segments, status): 60 requests per minute per
+  organization.
+
+Exceeding a limit returns `429` with a `Retry-After` header.

--- a/api-reference/endpoint/Text-Get-Template.mdx
+++ b/api-reference/endpoint/Text-Get-Template.mdx
@@ -1,0 +1,4 @@
+---
+title: 'Get SMS Template'
+openapi: 'GET /text/templates/{templateId}'
+---

--- a/api-reference/endpoint/Text-List-Templates.mdx
+++ b/api-reference/endpoint/Text-List-Templates.mdx
@@ -1,0 +1,4 @@
+---
+title: 'List SMS Templates'
+openapi: 'GET /text/templates'
+---

--- a/api-reference/endpoint/Text-Segments.mdx
+++ b/api-reference/endpoint/Text-Segments.mdx
@@ -1,0 +1,4 @@
+---
+title: 'Calculate SMS Segments'
+openapi: 'POST /text/segments'
+---

--- a/api-reference/endpoint/Text-Send.mdx
+++ b/api-reference/endpoint/Text-Send.mdx
@@ -1,0 +1,4 @@
+---
+title: 'Send a Text'
+openapi: 'POST /text/send'
+---

--- a/api-reference/endpoint/Text-Status.mdx
+++ b/api-reference/endpoint/Text-Status.mdx
@@ -1,0 +1,4 @@
+---
+title: 'Get Text Status'
+openapi: 'GET /text/status/{messageId}'
+---

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1184,8 +1184,8 @@
                   "count": 1,
                   "templates": [
                     {
-                      "templateId": 700,
-                      "accountId": "50041",
+                      "templateId": 100,
+                      "accountId": "99999",
                       "message": "{Consumer Name}, {Company Name} is a debt collector attempting to collect a debt. Visit {Website Payment} using your account# {Account Number} or call {Phone#}. Reply STOP to opt out.",
                       "placeholders": [
                         "Consumer Name",
@@ -1253,8 +1253,8 @@
                   "$ref": "#/components/schemas/SmsTemplate"
                 },
                 "example": {
-                  "templateId": 700,
-                  "accountId": "50041",
+                  "templateId": 100,
+                  "accountId": "99999",
                   "message": "{Consumer Name}, {Company Name} is a debt collector attempting to collect a debt. Visit {Website Payment} using your account# {Account Number} or call {Phone#}. Reply STOP to opt out.",
                   "placeholders": [
                     "Consumer Name",
@@ -1358,7 +1358,7 @@
                 },
                 "template": {
                   "value": {
-                    "templateId": 700,
+                    "templateId": 100,
                     "variables": {
                       "Consumer Name": "Jane"
                     }
@@ -1456,11 +1456,11 @@
               },
               "example": {
                 "destination": "3313048434",
-                "templateId": 700,
+                "templateId": 100,
                 "variables": {
                   "Consumer Name": "Jane Doe",
-                  "Company Name": "TSC Accounts Receivable",
-                  "Website Payment": "https://pay.collectwise.com/tsc",
+                  "Company Name": "Acme Recovery Group",
+                  "Website Payment": "https://pay.collectwise.com/acme",
                   "Account Number": "ACME-0001",
                   "Phone#": "800-555-0100"
                 },

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1151,6 +1151,506 @@
           }
         }
       }
+    },
+    "/text/templates": {
+      "get": {
+        "summary": "List SMS templates",
+        "description": "Lists every SMS template available to your organization, including the placeholder variables each one expects. Call this first to discover the `templateId` and the variable names to pass to the send endpoint.",
+        "responses": {
+          "200": {
+            "description": "Templates available to your organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "count",
+                    "templates"
+                  ],
+                  "properties": {
+                    "count": {
+                      "type": "integer",
+                      "description": "Number of templates returned."
+                    },
+                    "templates": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/SmsTemplate"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "count": 1,
+                  "templates": [
+                    {
+                      "templateId": 700,
+                      "accountId": "50041",
+                      "message": "{Consumer Name}, {Company Name} is a debt collector attempting to collect a debt. Visit {Website Payment} using your account# {Account Number} or call {Phone#}. Reply STOP to opt out.",
+                      "placeholders": [
+                        "Consumer Name",
+                        "Company Name",
+                        "Website Payment",
+                        "Account Number",
+                        "Phone#"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Texting is not enabled for your organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextError"
+                },
+                "example": {
+                  "error": "Texting is not enabled for this organization"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. See the Retry-After response header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextError"
+                },
+                "example": {
+                  "error": "Too many requests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/text/templates/{templateId}": {
+      "get": {
+        "summary": "Get an SMS template",
+        "description": "Fetches a single template's body and its placeholder variables.",
+        "parameters": [
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "The template's identifier."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The template.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SmsTemplate"
+                },
+                "example": {
+                  "templateId": 700,
+                  "accountId": "50041",
+                  "message": "{Consumer Name}, {Company Name} is a debt collector attempting to collect a debt. Visit {Website Payment} using your account# {Account Number} or call {Phone#}. Reply STOP to opt out.",
+                  "placeholders": [
+                    "Consumer Name",
+                    "Company Name",
+                    "Website Payment",
+                    "Account Number",
+                    "Phone#"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`templateId` is not a valid integer.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextError"
+                },
+                "example": {
+                  "error": "templateId must be an integer"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Texting is not enabled for your organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextError"
+                },
+                "example": {
+                  "error": "Texting is not enabled for this organization"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No template with that id exists in your organization's account.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextError"
+                },
+                "example": {
+                  "error": "Template not found"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextError"
+                },
+                "example": {
+                  "error": "Too many requests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/text/segments": {
+      "post": {
+        "summary": "Calculate SMS segments",
+        "description": "Returns how many SMS segments a message will use, matching the Twilio segment calculator. Provide either a raw `message`, or a `templateId` with `variables` (the template is rendered first, then counted). This endpoint does not send anything.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "description": "A raw message to measure. Provide this OR templateId."
+                  },
+                  "templateId": {
+                    "type": "integer",
+                    "description": "A template to render and measure. Provide this OR message."
+                  },
+                  "variables": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Values substituted into the template's placeholders (when using templateId)."
+                  }
+                }
+              },
+              "examples": {
+                "raw message": {
+                  "value": {
+                    "message": "Hi Jane, your balance is $430.10. Reply STOP to opt out."
+                  }
+                },
+                "template": {
+                  "value": {
+                    "templateId": 700,
+                    "variables": {
+                      "Consumer Name": "Jane"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Segment usage for the message.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SegmentResult"
+                },
+                "example": {
+                  "encoding": "GSM-7",
+                  "characterCount": 57,
+                  "gsm7Length": 57,
+                  "segmentCount": 1,
+                  "maxCharsPerSegment": 160,
+                  "messageSizeBits": 399
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Body had neither `message` nor `templateId`, or `templateId` was not an integer.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextError"
+                },
+                "example": {
+                  "error": "Provide either message or templateId"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextError"
+                },
+                "example": {
+                  "error": "Too many requests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/text/send": {
+      "post": {
+        "summary": "Send a one-time text",
+        "description": "Renders an SMS template with the supplied variables and sends it to one phone number. A 200 means the message was accepted and queued, not yet delivered — use the returned `messageId` with the status endpoint. Sandbox API keys are rejected.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "destination",
+                  "templateId",
+                  "variables",
+                  "debtorId"
+                ],
+                "properties": {
+                  "destination": {
+                    "type": "string",
+                    "description": "US phone number. `3313048434`, `13313048434`, and `+1 (331) 304-8434` are all accepted."
+                  },
+                  "templateId": {
+                    "type": "integer",
+                    "description": "The template to send. Must belong to your organization's account."
+                  },
+                  "variables": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Values substituted into the template's `{placeholder}` tokens. Use `{}` if the template has none. If any placeholder is left unresolved, the request fails with 400 rather than texting a literal `{token}`."
+                  },
+                  "debtorId": {
+                    "type": "string",
+                    "description": "Your reference for this recipient (e.g. your account or reference number). Forwarded as-is; replies and the message record are tracked against it."
+                  }
+                }
+              },
+              "example": {
+                "destination": "3313048434",
+                "templateId": 700,
+                "variables": {
+                  "Consumer Name": "Jane Doe",
+                  "Company Name": "TSC Accounts Receivable",
+                  "Website Payment": "https://pay.collectwise.com/tsc",
+                  "Account Number": "ACME-0001",
+                  "Phone#": "800-555-0100"
+                },
+                "debtorId": "your-reference-number"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Message accepted and queued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "messageId"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "messageId": {
+                      "type": "string",
+                      "description": "Delivery-tracking ID. Use it with the status endpoint."
+                    },
+                    "segments": {
+                      "$ref": "#/components/schemas/SegmentResult"
+                    }
+                  }
+                },
+                "example": {
+                  "success": true,
+                  "messageId": "1b1f0a9e-6f4e-4f4b-9a2e-1f2d3c4b5a69",
+                  "segments": {
+                    "encoding": "GSM-7",
+                    "segmentCount": 1,
+                    "characterCount": 142,
+                    "maxCharsPerSegment": 160
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid body: bad phone number, missing or non-integer `templateId`, missing `debtorId`, bad `variables`, or unresolved template placeholders.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextError"
+                },
+                "example": {
+                  "error": "Missing variables for placeholders: Consumer Name"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Texting not enabled for your organization, the template is not in your account, or a sandbox key was used.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextError"
+                },
+                "example": {
+                  "error": "Template is not available for your account"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextError"
+                },
+                "example": {
+                  "error": "Template not found"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded (10 sends/min per organization).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextError"
+                },
+                "example": {
+                  "error": "Too many requests"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "The SMS service rejected or failed the send.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextError"
+                },
+                "example": {
+                  "error": "Failed to send message"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextError"
+                },
+                "example": {
+                  "error": "Internal server error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/text/status/{messageId}": {
+      "get": {
+        "summary": "Get text delivery status",
+        "description": "Returns delivery status for a previously sent message. `messageId` is the value returned by the send endpoint. Delivery reports arrive asynchronously from the carrier, so poll after a short delay.",
+        "parameters": [
+          {
+            "name": "messageId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The messageId returned by the send endpoint."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current delivery status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageStatus"
+                },
+                "example": {
+                  "messageId": "1b1f0a9e-6f4e-4f4b-9a2e-1f2d3c4b5a69",
+                  "status": "Delivered",
+                  "delivered": true,
+                  "failed": false,
+                  "failureClassification": null,
+                  "retryRecommended": false,
+                  "createdAt": "2026-06-12T18:21:09.000Z",
+                  "updatedAt": "2026-06-12T18:21:14.000Z"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No message with that id for your organization.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextError"
+                },
+                "example": {
+                  "error": "Message not found"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextError"
+                },
+                "example": {
+                  "error": "Too many requests"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1821,6 +2321,135 @@
             "message": "start_date is required and must be YYYY-MM-DD or a full ISO 8601 UTC timestamp",
             "param": "start_date"
           }
+        }
+      },
+      "SmsTemplate": {
+        "type": "object",
+        "required": [
+          "templateId",
+          "accountId",
+          "message",
+          "placeholders"
+        ],
+        "properties": {
+          "templateId": {
+            "type": "integer",
+            "description": "Identifier for the template."
+          },
+          "accountId": {
+            "type": "string",
+            "description": "The account the template belongs to (your organization's configured account)."
+          },
+          "message": {
+            "type": "string",
+            "description": "The template body, containing `{placeholder}` tokens."
+          },
+          "placeholders": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Variable names you must supply in `variables` when sending."
+          }
+        }
+      },
+      "SegmentResult": {
+        "type": "object",
+        "required": [
+          "encoding",
+          "characterCount",
+          "segmentCount",
+          "maxCharsPerSegment"
+        ],
+        "properties": {
+          "encoding": {
+            "type": "string",
+            "enum": [
+              "GSM-7",
+              "UCS-2"
+            ],
+            "description": "Encoding the message is sent with. Any non-GSM-7 character (emoji, smart quotes, most CJK) forces the whole message to UCS-2."
+          },
+          "characterCount": {
+            "type": "integer",
+            "description": "Number of characters in the message."
+          },
+          "gsm7Length": {
+            "type": "integer",
+            "description": "Length in GSM-7 units (extended characters such as { } [ ] ~ \\ | ^ € cost 2)."
+          },
+          "segmentCount": {
+            "type": "integer",
+            "description": "Number of SMS segments the message will use."
+          },
+          "maxCharsPerSegment": {
+            "type": "integer",
+            "description": "Max characters per segment for the chosen encoding (160 GSM-7, 70 UCS-2)."
+          },
+          "messageSizeBits": {
+            "type": "integer",
+            "description": "Total message size in bits."
+          }
+        }
+      },
+      "MessageStatus": {
+        "type": "object",
+        "required": [
+          "messageId",
+          "status",
+          "delivered",
+          "failed"
+        ],
+        "properties": {
+          "messageId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "description": "Carrier status: Queued, Sent, Delivered, or Rejected / Failed / Undelivered on failure."
+          },
+          "delivered": {
+            "type": "boolean"
+          },
+          "failed": {
+            "type": "boolean"
+          },
+          "failureClassification": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "FATAL",
+              "NON_FATAL"
+            ],
+            "description": "On failed messages: FATAL (do not retry), NON_FATAL (transient, retry may succeed), or null when the carrier reason is unrecognized."
+          },
+          "retryRecommended": {
+            "type": "boolean",
+            "description": "True when the failure is NON_FATAL and a retry may succeed."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "TextError": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Human-readable error message."
+          }
+        },
+        "example": {
+          "error": "Texting is not enabled for this organization"
         }
       }
     },

--- a/mint.json
+++ b/mint.json
@@ -78,6 +78,17 @@
       ]
     },
     {
+      "group": "Texting",
+      "pages": [
+        "api-reference/Texting-Overview",
+        "api-reference/endpoint/Text-List-Templates",
+        "api-reference/endpoint/Text-Get-Template",
+        "api-reference/endpoint/Text-Segments",
+        "api-reference/endpoint/Text-Send",
+        "api-reference/endpoint/Text-Status"
+      ]
+    },
+    {
       "group": "Billing",
       "pages": [
         "api-reference/endpoint/Billing-Usage-Summary"


### PR DESCRIPTION
## What

Documents the new One-Time Text API (`/text/*`) in the Mintlify reference.

- **openapi.json** — 5 operations added under `/text` (list templates, get template, segments, send, status) plus `SmsTemplate`, `SegmentResult`, `MessageStatus`, `TextError` schemas. Additions only; the 16 existing paths and their formatting are untouched.
- **Endpoint pages** — 5 MDX stubs in `api-reference/endpoint/`, matching the existing OpenAPI-stub pattern.
- **Texting Overview** — a concept page (flow, templates/placeholders, segments/encoding, delivery status, rate limits), mirroring `Webhooks-Overview`.
- **mint.json** — new "Texting" navigation group between Communications and Billing.

## Scope decisions

- **Client-facing surface only.** The admin "on-behalf-of" params (`onBehalfOfOrgId` / `?orgId`) and the `accountId` / `campaignId` overrides are intentionally omitted from the public docs.
- **`templateId` is described without asserting global uniqueness** — the internal spec calls it globally unique, but the DB constraint is `@@unique([template_id, account_id, campaign_id])`, so the docs stay neutral.

## Before publishing

The docs server is production (`https://collectwiseapi.com`). These endpoints are live only after the texting feature merges to `main` and deploys with `SMS_MESSAGING_WEBHOOK_URL` pointed at the prod SMS service. Hold publish until then so readers don't hit 404s.

Validated locally: both JSON files parse, every nav entry resolves to a file, and each endpoint stub's `openapi:` ref matches an operation in the spec.
