### PR TITLE
Add Shadow cloud-agent harness

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://www.cursor.com/schemas/environment.schema.json",
+  "install": "bash .cursor/shadow-bootstrap.sh",
+  "agentCanUpdateSnapshot": true
+}

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "vault-mcp": {
+      "command": "python3",
+      "args": ["${userHome}/agent-configs/shared/mcp/vault-mcp/server.py"],
+      "env": { "SHADOW_LIB": "${userHome}/agent-configs/shared/bin" }
+    },
+    "grafana": {
+      "command": "uvx",
+      "args": ["mcp-grafana", "--disable-write"],
+      "env": {
+        "GRAFANA_URL": "https://collectwise.grafana.net",
+        "GRAFANA_SERVICE_ACCOUNT_TOKEN": "${env:GRAFANA_SERVICE_ACCOUNT_TOKEN}"
+      }
+    }
+  }
+}

--- a/.cursor/rules/assumption-audit.mdc
+++ b/.cursor/rules/assumption-audit.mdc
@@ -1,0 +1,16 @@
+---
+description: Audit your reasoning before acting:
+alwaysApply: true
+---
+
+Audit your reasoning before acting:
+
+1. **Name the assumptions.** What are you assuming about the user's intent, the code's behavior, the environment, the data shape, or the task scope?
+2. **Test grounding.** Is each assumption supported by (a) something the user said this turn, (b) tool output you've already read, or (c) memory from a prior session file? If none apply, the assumption is UNVERIFIED.
+3. **Resolve before acting.**
+   - Verify via a tool call (Read / Grep / Bash / REST) when cheap.
+   - Ask the user when the answer is non-obvious or the assumption is load-bearing.
+   - State the assumption explicitly in your reply when proceeding anyway ("I'm assuming X — correct if wrong").
+4. **Escalate for high-stakes work.** For production-touching changes, client-facing code, or reasoning chains longer than ~3 steps, run a structured assumption audit.
+
+Silence = danger. Unverified assumptions are the dominant source of shipped bugs and wasted rework.

--- a/.cursor/rules/code-quality.mdc
+++ b/.cursor/rules/code-quality.mdc
@@ -1,0 +1,10 @@
+---
+description: Make sure the code you create is clean, performant, and follows the DRY principle.
+alwaysApply: true
+---
+
+Make sure the code you create is clean, performant, and follows the DRY principle.
+
+Ensure modular, clean, concise, and well-written code that does exactly what the functionality at hand requires — nothing more.
+
+Do NOT add a "Co-Authored-By: Claude" trailer to git commit messages, and do NOT add a "Generated with Claude Code" (or any AI-attribution) line to PR bodies. Commits and pull requests must not be attributed to any AI agent.

--- a/.cursor/rules/observability.mdc
+++ b/.cursor/rules/observability.mdc
@@ -1,0 +1,29 @@
+---
+description: CollectWise observability — prod logs via Grafana Cloud Loki
+alwaysApply: true
+---
+
+# CollectWise observability — prod logs via Grafana Cloud Loki
+
+**When the user asks anything that boils down to "what is service X doing in prod" / "did Y happen" / "why did Z fail" / "show me logs from…" / errors / activity / job runs — the first move is a Loki query.** Do NOT propose `fly logs`, `aws logs tail`, the AWS console, or sshing into a machine unless (a) sub-second tail latency is required and the user said so, or (b) the Loki pipeline itself is suspected broken.
+
+## Two transports (same data, same read token)
+- **MCP-capable runtimes** (Claude, Cursor, OpenCode): use `mcp__grafana__query_loki_logs` against the unified Loki tenant. Load it via ToolSearch (`select:mcp__grafana__query_loki_logs`) if not present.
+- **Shell-only runtimes** (Codex cloud, CI, any sandbox without MCP): use `grafana-query.sh '<LogQL>' [--since 1h] [--limit 100]` (curl → Grafana instance proxy). Requires `GRAFANA_SERVICE_ACCOUNT_TOKEN` (read-only `glsa_` Viewer token) in the environment.
+
+Datasource UID: `grafanacloud-logs`. Stack: `https://collectwise.grafana.net`. All access read-only.
+
+## Canonical labels
+- `service` — `ai-paralegal`, `alert-probe`, `collectwise-api` (errors only), `collectwise-document-generation`, `email-service`, `forwarder-gateway`, `jambonz`, `livekit-sip`, `retell-voice`, `sftp-webhook`, `sms-messaging-service` (errors only), `workflow-scheduling`.
+- `env` — `prod`, `dev`, `synthetic`.
+- `source` — `fly` (Fly.io via Vector) or `cloudwatch` (Lambda via Amazon Data Firehose).
+
+## Query patterns
+- Single service: `{service="<name>"}`
+- Errors across every service: `{service=~".+"} |~ "(?i)error"`
+- Pipeline filter: `{source="fly"}` / `{source="cloudwatch"}`
+- Error rate: `sum by (service) (count_over_time({service=~".+"} |~ "(?i)error" [5m]))`
+
+## Gotchas
+- `collectwise-api` and `sms-messaging-service` ship **errors only** through a CloudWatch subscription filter — absence in label values means nothing errored, not a broken pipeline.
+- CloudWatch tail latency ~15–20s; Fly ~5–15s. For sub-second on Fly use `fly logs --app <name>`; on Lambda use `aws logs tail --follow` (both bypass Loki).

--- a/.cursor/rules/vault-gospel.mdc
+++ b/.cursor/rules/vault-gospel.mdc
@@ -1,0 +1,23 @@
+---
+description: The Obsidian vault is the canonical knowledge store
+alwaysApply: true
+---
+
+# The Obsidian vault is the canonical knowledge store
+
+Decisions, runbooks, ADRs, research, and session memory live in the vault — treat it as the source of truth. Code lives at its source path; the vault wikilinks to it. **Query the vault before generating ungrounded answers about the system.**
+
+## Access (transport-agnostic)
+- Search: `vault-cli.sh search "<query>"` (hybrid semantic+graph) or the `vault_search` MCP tool. Returns ranked notes with scores.
+- Read: `vault-cli.sh read <relpath>` or `vault_read`.
+- On the laptop the live `obsidian` CLI / Local REST API are also available; in a cloud sandbox the vault is a cloned git repo reached via the same `vault-cli.sh` / `vault-mcp` (resolved automatically by `vault-resolve.sh`).
+- The full conventions ("gospel") live in the vault's own `CLAUDE.md` (== `AGENTS.md`). Read it first when working in the vault.
+
+## Conventions
+- Notes only (no code/CSVs/binaries/>10MB — those stay at source and are wikilinked). Kebab-case filenames, ISO dates, YAML frontmatter, `[[wikilinks]]` over markdown links. ADRs: `decisions/NNNN-<slug>.md`.
+- Session memory: `_sessions/YYYY-MM-DD/HHMM-<agent>-<slug>.md`. Per-service knowledge mirrors `~/collectwise/repos/` under `collectwise/repos/<repo>/` (README, architecture, decisions, runbooks, incidents).
+
+## Session discipline
+1. **Load context at start** (recall): read relevant `_sessions/` + project notes before acting.
+2. **Write a session file on close** (handoff): summary + decisions, not transcripts.
+3. **Promote durable insight**: a decision → an ADR; a procedure → a runbook; otherwise a line in the daily note.

--- a/.cursor/shadow-bootstrap.sh
+++ b/.cursor/shadow-bootstrap.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# Token (a fine-grained read-only PAT over shivamratnani/{obsidian,agent-configs}) lets git
+# clone the private repos; without it we fall back to the sandbox's ambient creds.
+if [ -n "${SHADOW_GIT_TOKEN:-}" ]; then
+  git config --global credential.helper store
+  printf 'https://x-access-token:%s@github.com\n' "$SHADOW_GIT_TOKEN" > "$HOME/.git-credentials"
+  chmod 600 "$HOME/.git-credentials"
+fi
+AC="$HOME/agent-configs"
+git clone --depth=1 https://github.com/shivamratnani/agent-configs "$AC" 2>/dev/null \
+  || git -C "$AC" pull --quiet || true
+if [ -f "$AC/shared/bin/cloud-bootstrap.sh" ]; then bash "$AC/shared/bin/cloud-bootstrap.sh"
+else echo "shadow-bootstrap: agent-configs unavailable — set SHADOW_GIT_TOKEN secret"; fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+
+<!-- shadow-cloud-harness:start -->
+## Shadow cloud harness
+
+This repo is wired for Shadow cloud agents (Cursor / Codex / OpenCode / Claude). At setup,
+`cloud-bootstrap.sh` (from github.com/shivamratnani/agent-configs) clones the Obsidian vault,
+builds the search index, and writes `~/.shadow-env` — `source ~/.shadow-env` before working.
+
+- **Vault** (decisions/runbooks/session memory): `vault-cli.sh search|read|write`, `vault-sync.sh push|pull`, or the `vault_search`/`vault_read`/`vault_write` MCP tools. Query the vault before generating ungrounded answers.
+- **Prod logs**: `grafana-query.sh '<LogQL>' --since 1h` (needs `GRAFANA_SERVICE_ACCOUNT_TOKEN` secret), or `mcp__grafana__query_loki_logs`. Datasource `grafanacloud-logs`.
+- **Session discipline**: run recall at start; at end write `_sessions/YYYY-MM-DD/HHMM-<agent>-<slug>.md` and `vault-sync.sh push`.
+<!-- shadow-cloud-harness:end -->


### PR DESCRIPTION
Adds a thin `.cursor/` kit + an `AGENTS.md` section so cloud agents (Cursor / Codex / OpenCode / Claude) get vault search, Grafana prod logs, recall/handoff, and the always-on rules. The harness is pulled from github.com/shivamratnani/agent-configs at setup — nothing heavy is vendored here.

**Activate** with two secrets per cloud you use:
- `SHADOW_GIT_TOKEN` — fine-grained read-only PAT over `shivamratnani/{obsidian,agent-configs}`
- `GRAFANA_SERVICE_ACCOUNT_TOKEN` — read-only Loki Viewer token

Runbook: `agent-configs/docs/add-cloud-harness-to-repo.md`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/collectwise-dev/collectwise-api-docs/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->